### PR TITLE
Bugfix: check if variable is set

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -24,7 +24,7 @@ DEBOOTSTRAP_VER="1.0.91"
 #     None
 check_if_variable_is_set() {
     var_name=$1
-    if [ -z "${!var_name}" ]; then
+    if [ -z "${!var_name+x}" ]; then
         >&2 echo "${var_name} is not specified"
         exit 1
     fi


### PR DESCRIPTION
check_if_variable_is_set used to check if a variable is equal to an empty string. If it was not, the variable was considered to be set. It's not correct behaviour of the function.