### PR TITLE
Revert "Make docker-pieman.sh more portable"

### DIFF
--- a/pieman.sh
+++ b/pieman.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Copyright (C) 2017 Evgeny Golyshev <eugulixes@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
The reverted commit was supposed to change `docker-pieman.sh` instead of `pieman.sh`. By lack of attention, I approved the PR related to that. This commit corrects the mistake. 

Reverts tolstoyevsky/pieman#24