### PR TITLE
Add public keys to list of trusted keys

### DIFF
--- a/bootstrap/11-pm.sh
+++ b/bootstrap/11-pm.sh
@@ -17,6 +17,9 @@ for var in CREATE_ONLY_CHROOT ENABLE_NONFREE ENABLE_UNIVERSE ETC PIECES; do
     check_if_variable_is_set ${var}
 done
 
+# To prevent NO_PUBKEY when the packages will be installed a bit later.
+mark_keys_as_trusted
+
 if ${ALLOW_UNAUTHENTICATED}; then
     add_option_to_pm_options --allow-unauthenticated
 fi
@@ -24,9 +27,6 @@ fi
 if ${ENABLE_SUDO}; then
     add_package_to_includes sudo
 fi
-
-# apt-key dependency
-add_package_to_includes gnupg2
 
 # /etc/rc.firstboot dependencies
 add_package_to_includes parted

--- a/devices/rpi-2-b/ubuntu-artful-armhf/pieman.yml
+++ b/devices/rpi-2-b/ubuntu-artful-armhf/pieman.yml
@@ -16,6 +16,7 @@ ubuntu-artful-armhf:
   - https://github.com/raspberrypi/firmware/raw/master/boot/start.elf
   - https://github.com/raspberrypi/firmware/raw/master/boot/start_cd.elf
   - https://github.com/raspberrypi/firmware/raw/master/boot/start_x.elf
+  base: gnupg
   includes:
   # /usr/share/initramfs-tools/hooks/flash_kernel_set_root will be looking for
   # systemd-detect-virt during installation of the kernel.

--- a/devices/rpi-3-b/ubuntu-artful-arm64/pieman.yml
+++ b/devices/rpi-3-b/ubuntu-artful-arm64/pieman.yml
@@ -16,6 +16,7 @@ ubuntu-artful-arm64:
   - https://github.com/raspberrypi/firmware/raw/master/boot/start.elf
   - https://github.com/raspberrypi/firmware/raw/master/boot/start_cd.elf
   - https://github.com/raspberrypi/firmware/raw/master/boot/start_x.elf
+  base: gnupg
   includes:
   # /usr/share/initramfs-tools/hooks/flash_kernel_set_root will be looking for
   # systemd-detect-virt during installation of the kernel.

--- a/keys/devuan/raspberry-pi-archive-signing.key
+++ b/keys/devuan/raspberry-pi-archive-signing.key
@@ -1,0 +1,1 @@
+../raspbian/raspberry-pi-archive-signing.key

--- a/pieman.sh
+++ b/pieman.sh
@@ -108,6 +108,8 @@ ETC=${R}/etc
 
 USR_BIN=${R}/usr/bin
 
+BASE_PACKAGES=""
+
 IMAGE=${BUILD_DIR}/${PROJECT_NAME}/${PROJECT_NAME}.img
 
 KEYRING=/tmp/atomatically-generated-keyring.gpg
@@ -151,6 +153,14 @@ params="`get_attr_or_nothing ${OS} params`"
 for param in ${params}; do
     eval $param=true
 done
+
+# Expand the base system.
+base_packages="`get_attr_or_nothing ${OS} base`"
+if [ ! -z "${base_packages}" ]; then
+    for package in ${base_packages}; do
+        add_package_to_base_packages ${package}
+    done
+fi
 
 run_scripts "bootstrap"
 

--- a/pieman/attrs.py
+++ b/pieman/attrs.py
@@ -18,6 +18,7 @@ import yaml
 
 TYPES_SCHEME = {
     'repos': (list, ),
+    'base': (list, str),
     'includes': (list, str),
     'boot': (list, str),
     'params': (list, ),


### PR DESCRIPTION
It makes it possible to build images without running Pieman with `ALLOW_UNAUTHENTICATED=true`.