### PR TITLE
Call rsync with -p param

### DIFF
--- a/pieman.sh
+++ b/pieman.sh
@@ -217,4 +217,4 @@ umount "${MOUNT_POINT}"
 
 mount "${root_partition}" "${MOUNT_POINT}"
 
-rsync -a "${R}"/ "${MOUNT_POINT}"
+rsync -ap "${R}"/ "${MOUNT_POINT}"


### PR DESCRIPTION
It allows preserving permissions. Otherwise, some of the executables will lose the setuid bit and, for example, calling `sudo` will end up with `/usr/bin/sudo must be owned by uid 0 and have the setuid bit set`.
Fixes #46.