### PR TITLE
Use success message when chroot environment is done

### DIFF
--- a/bootstrap/11-pm.sh
+++ b/bootstrap/11-pm.sh
@@ -113,5 +113,7 @@ if ${CREATE_ONLY_CHROOT}; then
 
     cleanup
 
+    success "Chroot environment ${R} is done. Now you can speed up next builds by passing it to Pieman via the BASE_DIR parameter."
+
     exit 0
 fi


### PR DESCRIPTION
It's quite confusing when I can see the message "exiting since CREATE_ONLY_CHROOT is set to true" when I build chroot environment. Let's use 'Success' message style to emphasize that chroot environment is built successfully.