### PR TITLE
Use `bin/du.py` instead of `du`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Pieman is a script for creating custom OS images for single-board computers such
 * GNU Parted
 * GnuPG
 * mkpasswd
-* Python 3
+* Python (3.5 or higher)
 * PyYAML
 * rsync
 * Setuptools

--- a/bin/du.py
+++ b/bin/du.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python3
+# Copyright (C) 2018 Evgeny Golyshev <eugulixes@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# The main motivation to create a substitution for du is that it can sometimes
+# provide inaccurate result. For example, directory size may vary depending on
+# when du is called -- before or after transferring the directory to an image.
+
+import os
+import sys
+from optparse import OptionParser
+
+
+def get_tree_size(path, block_size=4096):
+    """Returns total size of files and number of files in the specified
+    directory.
+    """
+    total_size = items_number = 0
+
+    # os.walk skips the symbolic links that resolve to directories, not
+    # counting them at all. It has a great impact on the end result, so we need
+    # a different way to solve the task.
+    for dir_entry in os.scandir(path):
+        items_number += 1
+
+        if os.path.islink(dir_entry.path):
+            total_size += block_size
+        elif os.path.isdir(dir_entry.path):
+            ret = get_tree_size(dir_entry.path)
+            total_size += ret[0] + block_size
+            items_number += ret[1]
+        elif os.path.isfile(dir_entry.path):
+            file_size = os.path.getsize(dir_entry.path)
+            if file_size > block_size:
+                total_size += file_size
+            else:
+                total_size += block_size
+
+    return total_size, items_number
+
+
+def main():
+    parser = OptionParser(usage='usage: %prog [options] <directory>')
+    parser.add_option("-b", "--block-size", default=4096, type="int",
+                      help="block size", metavar="SIZE")
+    (options, args) = parser.parse_args()
+
+    if len(args) < 1:
+        parser.print_help()
+        sys.exit(1)
+
+    if not os.path.isdir(args[0]):
+        sys.stderr.write('The {} directory does not exist\n'.format(args[0]))
+        sys.exit(1)
+
+    total_size, items_number = get_tree_size(args[0], options.block_size)
+
+    print('Items number: {}'.format(items_number))
+    print('Total size: {}'.format(total_size))
+
+
+if __name__ == '__main__':
+    main()

--- a/functions.sh
+++ b/functions.sh
@@ -15,6 +15,10 @@
 
 DEBOOTSTRAP_VER="1.0.91"
 
+PYTHON_MAJOR_VER=3
+
+PYTHON_MINOR_VER=5
+
 # Checks if the specified variable is set.
 # Globals:
 #     None
@@ -182,6 +186,12 @@ check_dependencies() {
         exit 1
     fi
 
+    if ! $(check_python_version); then
+        fatal "Python ${PYTHON_MAJOR_VER}.${PYTHON_MINOR_VER} or higher is required." \
+              "$(${PYTHON} -V) is used instead."
+        exit 1
+    fi
+
     if ! ${PYTHON} -c "import yaml"; then
         fatal "there is no yaml python package." \
               "Run apt-get install python3-yaml on Debian/Ubuntu or" \
@@ -239,6 +249,26 @@ check_mutually_exclusive_params() {
             fi
         done
     done
+}
+
+# Checks if the current Python version is equal or greater than required.
+# Globals:
+#     PYTHON_MAJOR_VER
+#     PYTHON_MINOR_VER
+# Arguments:
+#     None
+# Returns:
+#     Boolean
+check_python_version() {
+    local current_python_version=()
+
+    IFS='.' read -ra current_python_version <<< $(${PYTHON} -V | cut -d' ' -f2)
+
+    if (("${current_python_version[0]}" >= "${PYTHON_MAJOR_VER}")) && (("${current_python_version[1]}" >= "${PYTHON_MINOR_VER}")); then
+        true
+    else
+        false
+    fi
 }
 
 # Chooses a suitable compressor depending on which parameters passed (or didn't

--- a/pieman.sh
+++ b/pieman.sh
@@ -227,7 +227,7 @@ umount "${MOUNT_POINT}"
 
 mount "${root_partition}" "${MOUNT_POINT}"
 
-rsync -ap "${R}"/ "${MOUNT_POINT}"
+rsync -apS "${R}"/ "${MOUNT_POINT}"
 
 cleanup
 

--- a/pieman.sh
+++ b/pieman.sh
@@ -186,10 +186,7 @@ run_scripts "bootstrap"
 umount_required_filesystems
 
 info "creating image"
-# The root partition definitely won't be 100% full, since the rootfs size is
-# larger on the host system than it will be after copying to the root
-# partition. Probably it's because of the fragmentation.
-create_image "$(du -s "${R}" | cut -f1)"
+create_image "$(calc_size "${R}")"
 
 LOOP_DEV=$(losetup --partscan --show --find "${IMAGE}")
 boot_partition="${LOOP_DEV}p1"


### PR DESCRIPTION
`bin/du.py` calculates more accurately the size of the target chroot environment than `du`.
I collected all the logs from cusdeb.com related to `rsync` and the `No space left on device` error. The following `INCLUDES` resulted in the error:
* `INCLUDES=0install,389-admin,389-admin-console,aapt,ssh`
* `INCLUDES=uhd-host,swig,gnuradio-dev,gnuradio,gr-osmosdr,gr-radar,gr-rds,gr-air-modes,gr-radar-doc,gr-iio,nano,minicom,wifite`
* `INCLUDES=php,nano,apache2,tightvncserver,phpmyadmin,pptpd,vsftpd,php-cli`
* `INCLUDES=python3,python3-all,gnuradio,gnuradio-doc,gnuradio-dev`
* `INCLUDES=lxde`
* `INCLUDES=opencv-data,python-opencv`
* `INCLUDES=0install`
* `INCLUDES=php7.0,nginx,mysql-server`

I used the `INCLUDES` as test cases for the changes and everything is fine.