### PR TITLE
Do not modify /etc/sudoers

### DIFF
--- a/bootstrap/20-users.sh
+++ b/bootstrap/20-users.sh
@@ -32,7 +32,7 @@ if ${ENABLE_USER}; then
             permission="ALL=(ALL) NOPASSWD: ALL"
         fi
 
-        sed -i "/root\tALL=(ALL:ALL) ALL/a ${USER_NAME}\t${permission}" ${ETC}/sudoers
+        echo "${USER_NAME} ${permission}" > ${ETC}/sudoers.d/01_allow_executing_any_command
     fi
 fi
 


### PR DESCRIPTION
Put a file with rules to /etc/sudoers.d instead. There are a couple of reasons to do that.
* It's not recommended to modify /etc/sudoers directly.
* The code, which is responsible for modification of /etc/sudoers, relies on on the content of the file which may vary from distro to distro.