### PR TITLE
Combine apk and debootstrap in an entity called toolset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ build
 debootstrap
 dist
 pieman.egg-info
+toolset
 __pycache__
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Pieman is a script for creating custom OS images for single-board computers such
 
 #### Mandatary
 
-* debootstrap
 * dosfstools
 * dpkg
 * GNU Parted
@@ -118,18 +117,7 @@ First, clone the Pieman git repo:
 $ git clone https://github.com/tolstoyevsky/pieman.git
 ```
 
-Then, go into the newly created directory and clone the debootstrap git repo there. Pieman requires debootstrap `1.0.105` or higher.
-
-```
-$ cd pieman
-$ git clone https://salsa.debian.org/installer-team/debootstrap.git
-$ cd debootstrap
-$ git checkout 1.0.105
-```
-
-If your distribution has debootstrap 1.0.105 or higher (for example, Ubuntu 18.04), you can skip this step and install it via a package manager.
-
-Next, install the rest of the Pieman dependencies.
+Then, install the Pieman dependencies.
 
 On Debian or Ubuntu:
 
@@ -224,15 +212,27 @@ Allows specifying the projects location. By default, the directory named `build`
 
 ##### CREATE_ONLY_CHROOT=false
 
-Makes Pieman restrict itself to creating only a chroot environment based on the operating system specified via `OS`. The chroot environment is stored in `build/${PROJECT_NAME}/chroot` and can be used immediately or later to reduce the time of building images. See `BASE_DIR`.
+Makes Pieman restrict itself to only creating a chroot environment based on the operating system specified via `OS`. The chroot environment is stored in `build/${PROJECT_NAME}/chroot` and can be used immediately or later to reduce the time of building images. See `BASE_DIR`.
 
 ##### LOCALE="en_US.UTF-8"
 
 Allows specifying the locale.
 
+##### PIEMAN_DIR="$(pwd)"
+
+Allows specifying the directory into which Pieman is installed.
+
+##### PREPARE_ONLY_TOOLSET=false
+
+Makes Pieman restrict itself to only preparing or upgrading the toolset which is located in the directory specified via `TOOLSET_DIR`.
+
 ##### TIME_ZONE="Etc/UTC"
 
 Specifies the time zone of the system.
+
+##### TOOLSET_DIR="${PIEMAN_DIR}/toolset"
+
+Allows specifying the directory which contains the tools necessary for creating chroot environments based on Alpine Linux and different Debian-based distributions. The toolset consists of [debootstrap](https://wiki.debian.org/Debootstrap) and [apk.static](https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management).
 
 ---
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,6 @@ FROM alpine:3.7
 
 ENV BRANCH master
 
-ENV DEBOOTSTRAP_VER 1.0.105
-
 ENV TERM linux
 
 ARG VCS_REF
@@ -44,9 +42,8 @@ RUN touch .dockerenv \
  && cd \
  && git clone -b $BRANCH --depth 1 https://github.com/tolstoyevsky/pieman.git \
  && cd pieman \
- && git clone https://anonscm.debian.org/git/d-i/debootstrap.git \
- && cd debootstrap && git checkout $DEBOOTSTRAP_VER && cd .. \
  && pip3 install pieman \
+ && env PREPARE_ONLY_TOOLSET=true ./pieman.sh \
  && apk del git \
  && rm -rf /var/cache/apk/*
 

--- a/essentials.sh
+++ b/essentials.sh
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+ALPINE_VER="3.7"
+
 DEBOOTSTRAP_VER="1.0.105"
 
 PIEMAN_MAJOR_VER=0
@@ -135,6 +137,17 @@ def_protected_var() {
     eval ${var_name}="\"${value}\""
 
     >&2 echo "+ ${var_name}=*****"
+}
+
+# Gets the ownership of the specified file or directory.
+# Globals:
+#     None
+# Arguments:
+#     File name or directory name
+# Returns:
+#     Ownership in format "uid:gid"
+get_ownership() {
+    echo "$(id -u "$(stat -c "%U" "$1")"):$(id -g "$(stat -c "%G" "$1")")"
 }
 
 # Runs all scripts which are located in the specified directory.

--- a/helpers/apk.sh
+++ b/helpers/apk.sh
@@ -13,50 +13,38 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Gets the Alpine Package Keeper version.
+# Gets the Alpine Package Keeper (APK) version for the specified version of
+# Alpine Linux.
 # Globals:
 #     PIECES
-#     PIEMAN_BIN
+#     PIEMAN_UTILS_DIR
 #     PYTHON
 # Arguments:
-#     None
+#     Version of Alpine Linux
 # Returns:
-#     Version
+#     Alpine Package Keeper version
 get_apk_tools_version() {
-    ${PYTHON} "${PIEMAN_BIN}"/apk-tools-version.py --alpine-version="${PIECES[1]}"
+    local alpine_version=$1
+
+    ${PYTHON} "${PIEMAN_UTILS_DIR}"/apk-tools-version.py --alpine-version="${alpine_version}"
 }
 
-# Gets the latest version of apk.static for the specified Alpine release and
-# runs it to build a chroot environment.
+# Runs apk.static to build a chroot environment.
 # Globals:
 #     BASE_PACKAGES
-#     BUILD_DIR
 #     ETC
 #     OS
 #     PIECES
 #     R
-#     PROJECT_NAME
+#     TOOLSET_DIR
 # Arguments:
 #     None
 # Returns:
 #     None
 run_apk_static() {
-    local apk_tools_version=""
-    local apk_tools_static=""
-    local primary_repo=""
-
-    apk_tools_version="$(get_apk_tools_version)"
-    apk_tools_static="apk-tools-static-${apk_tools_version}.apk"
+    local primary_repo
 
     primary_repo="$(get_attr "${OS}" repos | head -n1)"
-
-    cd "${BUILD_DIR}/${PROJECT_NAME}" || exit 1
-        wget "${primary_repo}/v${PIECES[1]}/main/armhf/${apk_tools_static}" -O "${apk_tools_static}"
-
-        tar -xzf "${apk_tools_static}"
-
-        rm "${apk_tools_static}"
-    cd - || exit 1
 
     mkdir -p "${R}"/usr/bin
 
@@ -64,7 +52,7 @@ run_apk_static() {
 
     # Ignore SC2086 since BASE_PACKAGES shouldn't be double-quoted.
     # shellcheck disable=SC2086
-    "${BUILD_DIR}/${PROJECT_NAME}"/sbin/apk.static -X "${primary_repo}/v${PIECES[1]}/main" -U --allow-untrusted --root "${R}" --initdb add alpine-base ${BASE_PACKAGES}
+    "${TOOLSET_DIR}/apk/${PIECES[1]}/apk.static" -X "${primary_repo}/v${PIECES[1]}/main" -U --allow-untrusted --root "${R}" --initdb add alpine-base ${BASE_PACKAGES}
 
     echo "nameserver 8.8.8.8" > "${ETC}"/resolv.conf
 }

--- a/helpers/base.sh
+++ b/helpers/base.sh
@@ -249,52 +249,6 @@ choose_compressor() {
     fi
 }
 
-# Looks for debootstrap installed locally. If it does not exist, tries to find
-# debootstrap installed globally. When the function succeeds, it assigns the
-# corresponding executable name to DEBOOTSTRAP_EXEC and the full path of the
-# executable to DEBOOTSTRAP_DIR (only in case of a local debootstrap).
-# Otherwise, the function exits with the exit code 1.
-# Globals:
-#     DEBOOTSTRAP_DIR
-#     DEBOOTSTRAP_EXEC
-# Arguments:
-#     None
-# Returns:
-#     None
-choose_debootstrap() {
-    local ver=""
-
-    if [ -f debootstrap/debootstrap ]; then
-        DEBOOTSTRAP_EXEC="env DEBOOTSTRAP_DIR=$(pwd)/debootstrap ./debootstrap/debootstrap"
-
-        # After cloning the debootstrap git repo the program is a fully
-        # functional, but does not have a correct version number. However, the
-        # version can be found in the source package changelog.
-        ver=$(sed 's/.*(\(.*\)).*/\1/; q' debootstrap/debian/changelog)
-    elif [ ! -z "$(which debootstrap)" ]; then
-        DEBOOTSTRAP_EXEC=$(which debootstrap)
-        ver=$(${DEBOOTSTRAP_EXEC} --version | awk '{print $2}' || /bin/true)
-    else
-        fatal "there is no debootstrap." \
-              "It's recommended to install the latest version of the program" \
-              "using its git repo:" \
-              "https://anonscm.debian.org/git/d-i/debootstrap.git"
-        exit 1
-    fi
-
-    if [ -z "${ver}" ]; then
-        fatal "your debootstrap seems to be broken. Could not get its version."
-        exit 1
-    fi
-
-    if dpkg --compare-versions "${ver}" lt "${DEBOOTSTRAP_VER}"; then
-        fatal "debootstrap ${DEBOOTSTRAP_VER} or higher is required."
-        exit 1
-    fi
-
-    info "using ${DEBOOTSTRAP_EXEC}"
-}
-
 # Chooses the corresponding user mode emulation binary and assigns its full
 # path to the EMULATOR environment variable. The binary depends on the
 # architecture of the operating system which is going to be used as a base for

--- a/helpers/deb.sh
+++ b/helpers/deb.sh
@@ -13,6 +13,55 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Declares the DEBOOTSTRAP_EXEC environment variable which then can be used to
+# execute debootstrap.
+# Globals:
+#     DEBOOTSTRAP_DIR
+#     DEBOOTSTRAP_EXEC
+#     DEBOOTSTRAP_VER
+# Arguments:
+#     None
+# Returns:
+#     None
+init_debootstrap() {
+    local path_to_debootstrap="${TOOLSET_DIR}/debootstrap"
+    local ver=""
+
+    DEBOOTSTRAP_EXEC="env DEBOOTSTRAP_DIR=${path_to_debootstrap} ${path_to_debootstrap}/debootstrap"
+
+    info "using ${DEBOOTSTRAP_EXEC}"
+}
+
+# Checks if debootstrap is equal to or higher than the version specified in the
+# DEBOOTSTRAP_VER environment variable.
+# Globals:
+#     DEBOOTSTRAP_VER
+#     PIEMAN_DIR
+#     TOOLSET_DIR
+# Arguments:
+#     None
+# Returns:
+#     Boolean
+is_debootstrap_uptodate() {
+    local path_to_debootstrap="${TOOLSET_DIR}/debootstrap"
+
+    # After cloning the debootstrap git repo the program is a fully
+    # functional, but does not have a correct version number. However, the
+    # version can be found in the source package changelog.
+    ver=$(sed 's/.*(\(.*\)).*/\1/; q' "${path_to_debootstrap}"/debian/changelog)
+
+    if [ -z "${ver}" ]; then
+        fatal "your debootstrap seems to be broken. Could not get its version."
+        exit 1
+    fi
+
+    if dpkg --compare-versions "${ver}" lt "${DEBOOTSTRAP_VER}"; then
+        false
+    else
+        true
+    fi
+}
+
 # Runs the first stage of building a chroot environment based on a Debian-based
 # distribution. Then it installs a user mode emulation binary to the chroot.
 # Globals:

--- a/helpers/fs.sh
+++ b/helpers/fs.sh
@@ -26,7 +26,7 @@ calc_size() {
 
     block_size="$(grep "blocksize" /etc/mke2fs.conf | head -n1 | cut -d'=' -f2 | xargs)"
 
-    ${PYTHON} "${PIEMAN_BIN}"/du.py --block-size="${block_size}" "${dir}" | grep "Total size" | cut -d':' -f2 | xargs
+    ${PYTHON} "${PIEMAN_UTILS_DIR}"/du.py --block-size="${block_size}" "${dir}" | grep "Total size" | cut -d':' -f2 | xargs
 }
 
 # Checks if the required directories exist.

--- a/helpers/image-attribs.sh
+++ b/helpers/image-attribs.sh
@@ -26,7 +26,7 @@
 get_attr() {
     local output=""
 
-    output="$(${PYTHON} "${PIEMAN_BIN}"/image_attrs.py --file="${YML_FILE}" "$@" 2>&1)"
+    output="$(${PYTHON} "${PIEMAN_UTILS_DIR}"/image_attrs.py --file="${YML_FILE}" "$@" 2>&1)"
     # TODO: check exit code directly with e.g. 'if mycmd;'
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
@@ -48,5 +48,5 @@ get_attr() {
 # Returns:
 #     Image attribute value
 get_attr_or_nothing() {
-    ${PYTHON} "${PIEMAN_BIN}"/image_attrs.py --file="${YML_FILE}" "$@" 2> /dev/null || /bin/true
+    ${PYTHON} "${PIEMAN_UTILS_DIR}"/image_attrs.py --file="${YML_FILE}" "$@" 2> /dev/null || /bin/true
 }

--- a/pieman.sh
+++ b/pieman.sh
@@ -68,7 +68,7 @@ def_var ENABLE_USER true
 
 def_var HOST_NAME "pieman-${DEVICE}"
 
-def_var IMAGE_OWNERSHIP "$(id -u "$(stat -c "%U" "$0")"):$(id -g "$(stat -c "%G" "$0")")"
+def_var IMAGE_OWNERSHIP "$(get_ownership "$0")"
 
 def_var INCLUDES ""
 
@@ -78,15 +78,21 @@ def_var OS "raspbian-stretch-armhf"
 
 def_protected_var PASSWORD "secret"
 
-def_var PROJECT_NAME "$(uuidgen)"
+def_var PIEMAN_DIR "$(pwd)"
 
-def_var PIEMAN_BIN 'pieman/bin'
+def_var PIEMAN_UTILS_DIR "${PIEMAN_DIR}/pieman/bin"
+
+def_var PREPARE_ONLY_TOOLSET false
+
+def_var PROJECT_NAME "$(uuidgen)"
 
 def_var PYTHON "$(which python3)"
 
 def_var SUDO_REQUIRE_PASSWORD true
 
 def_var TIME_ZONE "Etc/UTC"
+
+def_var TOOLSET_DIR "${PIEMAN_DIR}/toolset"
 
 def_var USER_NAME "cusdeb"
 
@@ -131,6 +137,9 @@ split_os_name_into_pieces
 
 run_scripts "helpers"
 
+info "checking toolset"
+. toolset.sh
+
 check_mutually_exclusive_params \
     BASE_DIR \
     CREATE_ONLY_CHROOT
@@ -154,9 +163,9 @@ check_required_directories
 
 check_required_files
 
-choose_debootstrap
-
 choose_user_mode_emulation_binary
+
+init_debootstrap
 
 set_traps
 

--- a/toolset.sh
+++ b/toolset.sh
@@ -1,0 +1,71 @@
+# Copyright (C) 2018 Evgeny Golyshev <eugulixes@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+if [ ! -d "${TOOLSET_DIR}/apk/${ALPINE_VER}" ]; then
+    create_dir "${TOOLSET_DIR}/apk/${ALPINE_VER}"
+
+    info "fetching apk.static for Alpine Linux ${ALPINE_VER}"
+    pushd "${TOOLSET_DIR}"/apk
+        addr=http://dl-cdn.alpinelinux.org/alpine/
+        apk_tools_version="$(get_apk_tools_version "${ALPINE_VER}")"
+        apk_tools_static="apk-tools-static-${apk_tools_version}.apk"
+        apk_tools_static_path="${TOOLSET_DIR}/apk/${ALPINE_VER}"
+
+        wget "${addr}/v${ALPINE_VER}/main/armhf/${apk_tools_static}" -O "${apk_tools_static_path}/${apk_tools_static}"
+
+        tar -xzf "${apk_tools_static_path}/${apk_tools_static}" -C "${apk_tools_static_path}"
+
+        mv "${apk_tools_static_path}/sbin/apk.static" "${apk_tools_static_path}"
+
+        rm    "${apk_tools_static_path}/${apk_tools_static}"
+        rm -r "${apk_tools_static_path}/sbin"
+    popd
+fi
+
+if [ ! -d "${TOOLSET_DIR}/debootstrap" ]; then
+    info "fetching debootstrap ${DEBOOTSTRAP_VER}"
+    pushd "${TOOLSET_DIR}"
+        git clone https://salsa.debian.org/installer-team/debootstrap.git
+
+        git -C debootstrap checkout "${DEBOOTSTRAP_VER}"
+    popd
+else
+    info "checking if the debootstrap version is equal to or higher ${DEBOOTSTRAP_VER}"
+
+    if ! is_debootstrap_uptodate; then
+        pushd "${TOOLSET_DIR}"/debootstrap
+            info "upgrading debootstrap to ${DEBOOTSTRAP_VER}"
+
+            git checkout master
+
+            git pull
+
+            git checkout ${DEBOOTSTRAP_VER}
+        popd
+    fi
+fi
+
+# Correct ownership if needed
+pieman_dir_ownership="$(get_ownership "${PIEMAN_DIR}")"
+if [ "$(get_ownership "${TOOLSET_DIR}")" != "${pieman_dir_ownership}" ]; then
+    info "correcting ownership for ${TOOLSET_DIR}"
+    chown -R "${pieman_dir_ownership}" "${TOOLSET_DIR}"
+fi
+
+if ${PREPARE_ONLY_TOOLSET}; then
+    info "exiting since PREPARE_ONLY_TOOLSET is set to true"
+
+    exit 0
+fi


### PR DESCRIPTION
* `debootstrap` is not required to be installed manually anymore.
* `apk.static` is not fetched every single time when images based on Alpine Linux are built.
* Before running Pieman checks the toolset. If it lacks some of the tools, it will install them itself.