### PR TITLE
Keep only bcm2837-rpi-3-b.dtb in 64-bit images for RPi 3

### DIFF
--- a/devices/rpi-3-b/ubuntu-bionic-arm64/pieman.yml
+++ b/devices/rpi-3-b/ubuntu-bionic-arm64/pieman.yml
@@ -7,7 +7,6 @@ ubuntu-bionic-arm64:
   - cmdline.txt
   - config.txt
   - /boot/vmlinuz-4.15.0-*-raspi2:kernel8.img
-  - /lib/firmware/4.15.0-*-raspi2/device-tree/broadcom/bcm2710-rpi-3-b.dtb
   - /lib/firmware/4.15.0-*-raspi2/device-tree/broadcom/bcm2837-rpi-3-b.dtb
   - https://github.com/raspberrypi/firmware/raw/master/boot/bootcode.bin
   - https://github.com/raspberrypi/firmware/raw/master/boot/fixup.dat


### PR DESCRIPTION
Closed #97 