### PR TITLE
Fix chroot building

### DIFF
--- a/pieman.sh
+++ b/pieman.sh
@@ -175,10 +175,6 @@ check_mutually_exclusive_params \
     CREATE_ONLY_CHROOT \
     ENABLE_MENDER
 
-check_mutually_exclusive_params \
-    IMAGE_ROOTFS_SIZE \
-    CREATE_ONLY_CHROOT
-
 check_dependencies
 
 check_ownership_format


### PR DESCRIPTION
`IMAGE_ROOTFS_SIZE` and `CREATE_ONLY_CHROOT` do not conflict with each other, so no need to call `check_mutually_exclusive_params`