### PR TITLE
Add systemd-sysv to all Raspbian images

### DIFF
--- a/bootstrap/12-pm.sh
+++ b/bootstrap/12-pm.sh
@@ -28,7 +28,7 @@ fi
 if ${ENABLE_MENDER} || ${CREATE_ONLY_MENDER_ARTIFACT}; then
     add_package_to_includes ca-certificates
     # Need to have the reboot executable file in $PATH
-    add_package_to_includes systemd-sysv
+    # Solved by adding systemd-sysv to pieman.yml
 fi
 
 if ${ENABLE_SUDO}; then

--- a/devices/rpi-b/raspbian-stretch-armhf/pieman.yml
+++ b/devices/rpi-b/raspbian-stretch-armhf/pieman.yml
@@ -21,5 +21,6 @@ raspbian-stretch-armhf:
   - https://github.com/raspberrypi/firmware/raw/master/boot/start.elf
   - https://github.com/raspberrypi/firmware/raw/master/boot/start_cd.elf
   - https://github.com/raspberrypi/firmware/raw/master/boot/start_x.elf
+  includes: systemd-sysv
   kernel:
     package: raspberrypi-kernel


### PR DESCRIPTION
Add `halt`, `reboot` and `shutdown` commands to Raspbian builds

# Please make sure all below checkboxes in the Mandatory section have been checked before submitting your PR (also don't forget to pay attention to the Depending on Circumstances section)

## Mandatory

- [x] The commit message is an imperative and starts with a capital letter (for example, `Add something`, `Remove something`, `Fix something`, etc.).
- [x] I made sure I hadn't put a period at the end of the the commit message(s).

## Depending on Circumstances

Some of the items in the section become mandatory if you are a first-time contributor and/or your changes are relevant to the items.

- [ ] Adding a new parameter I didn't forget to reflect it in `README.md`.
- [ ] Adding a new parameter or modifying an existing one I didn't break the alphabetical order.
- [ ] Adding a new utility written in Python I didn't forget to reflect it in `pieman/README.md`.
- [ ] Adding a new utility written in Python I didn't forget to increase the version number of the [pieman](https://pypi.org/project/pieman/) package in `pieman/setup.py`, `pieman/pieman/__init__.py` and `essentials.sh`.
- [ ] (for first-time contributors) One of the commits in the pull request adds me to the **Acknowledgements** section in `AUTHORS.md`.
