### PR TITLE
Fix checking Bash version in docker-pieman.sh

### DIFF
--- a/docker-pieman.sh
+++ b/docker-pieman.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-if [[ ${BASH_VERSION} != 4.* ]]; then
+if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
     >&2 echo "$0 requires bash 4 or higher"
     exit 1
 fi


### PR DESCRIPTION
The old variant of checking the version of Bash doesn't take Bash 5 into account.

# Please make sure all below checkboxes in the Mandatory section have been checked before submitting your PR (also don't forget to pay attention to the Depending on Circumstances section)

## Mandatory

- [x] The commit message is an imperative and starts with a capital letter (for example, `Add something`, `Remove something`, `Fix something`, etc.).
- [x] I made sure I hadn't put a period at the end of the the commit message(s).

## Depending on Circumstances

Some of the items in the section become mandatory if you are a first-time contributor and/or your changes are relevant to the items.

- [ ] Adding a new parameter I didn't forget to reflect it in `README.md`.
- [ ] Adding a new parameter or modifying an existing one I didn't break the alphabetical order.
- [ ] Adding a new utility written in Python I didn't forget to reflect it in `pieman/README.md`.
- [ ] Adding a new utility written in Python I didn't forget to increase the version number of the [pieman](https://pypi.org/project/pieman/) package in `pieman/setup.py`, `pieman/pieman/__init__.py` and `essentials.sh`.
- [ ] (for first-time contributors) One of the commits in the pull request adds me to the **Acknowledgements** section in `AUTHORS.md`.
