### PR TITLE
Move qemu-user-static to toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Pieman is a core component of [CusDeb](https://cusdeb.com).
   * pandoc
   * rsync
   * uuidgen
-  * User mode emulation binaries such as `/usr/bin/qemu-arm-static` and `/usr/bin/qemu-aarch64-static`
   * wget
   * which
   * xz
@@ -80,11 +79,11 @@ Pieman is a core component of [CusDeb](https://cusdeb.com).
 Here are the commands to install the mandatory dependencies
 * on Debian or Ubuntu
   ```
-  $ sudo apt-get install bison dosfstools flex gcc git gnupg make pandoc parted python-dev python3-pip python3-setuptools swig qemu-user-static rsync uuid-runtime wget whois xz-utils
+  $ sudo apt-get install bison dosfstools flex gcc git gnupg make pandoc parted python-dev python3-pip python3-setuptools swig rsync uuid-runtime wget whois xz-utils
   ```
 * on Fedora
   ```
-  $ sudo dnf install bison dosfstools dpkg expect flex gcc git gpg make pandoc parted python2-devel python3-pip python3-setuptools qemu-user-static rsync swig wget which xz
+  $ sudo dnf install bison dosfstools dpkg expect flex gcc git gpg make pandoc parted python2-devel python3-pip python3-setuptools rsync swig wget which xz
   ```
 
 #### Optional
@@ -305,7 +304,7 @@ Restricts Pieman to only preparing or upgrading the toolset which is located in 
 
 Specifies the time zone of the system.
 
-##### TOOLSET_CODENAME="v1-bender"
+##### TOOLSET_CODENAME="v2-hermes"
 
 Specifies the toolset codename. The parameter allows users and developers to switch between different toolsets. Each codename is connected to its directory in `${TOOLSET_DIR}` which, in turn, contains the target toolset. When a codename is passed via `${TOOLSET_CODENAME}` but there is no such directory in `${TOOLSET_DIR}`, the process of creating of the directory and installing the toolset into it will be initiated.
 

--- a/docker/rollout_fixes.sh
+++ b/docker/rollout_fixes.sh
@@ -4,23 +4,11 @@ set -e
 
 mkdir packages
 
-#
-# qemu-arm-static
-#
-
 wget http://ftp.debian.org/debian/dists/stretch/main/binary-amd64/Packages.xz
 
 xz -d Packages.xz
 
 cd packages
-
-package=$(grep "Filename: pool/main/q/qemu/qemu-user-static" ../Packages | awk '{print $2}')
-
-wget http://ftp.debian.org/debian/${package}
-
-ar x $(basename ${package})
-
-tar xJvf data.tar.xz
 
 #
 # zlib1g
@@ -36,8 +24,6 @@ ar x $(basename ${package})
 
 tar xJvf data.tar.xz
 
-cp usr/bin/qemu-arm-static /usr/bin
-cp usr/bin/qemu-aarch64-static /usr/bin
 cp lib/x86_64-linux-gnu/libz.so.1.2.8 /usr/glibc-compat/lib/libz.so.1
 
 cd ..

--- a/helpers/base.sh
+++ b/helpers/base.sh
@@ -57,20 +57,6 @@ check_dependencies() {
         exit 1
     fi
 
-    if [ ! -e /usr/bin/qemu-arm-static ]; then
-        fatal "there is no /usr/bin/qemu-arm-static." \
-              "Run apt-get install qemu-user-static on Debian/Ubuntu or" \
-              "dnf install qemu-user-static on Fedora."
-        exit 1
-    fi
-
-    if [ ! -e /usr/bin/qemu-aarch64-static ]; then
-        fatal "there is no /usr/bin/qemu-aarch64-static."
-              "Run apt-get install qemu-user-static on Debian/Ubuntu or" \
-              "dnf install qemu-user-static on Fedora."
-        exit 1
-    fi
-
     if [ -z "$(which mkpasswd)" ]; then
         fatal "there is no mkpasswd." \
               "Run apt-get install whois on Debian/Ubuntu or" \
@@ -253,11 +239,11 @@ choose_user_mode_emulation_binary() {
 
     case ${PIECES[2]} in
     armhf)
-        EMULATOR=/usr/bin/qemu-arm-static
+        EMULATOR="${TOOLSET_FULL_PATH}"/qemu-user-static/qemu-arm-static
         ;;
     arm64)
         # shellcheck disable=SC2034
-        EMULATOR=/usr/bin/qemu-aarch64-static
+        EMULATOR="${TOOLSET_FULL_PATH}"/qemu-user-static/qemu-aarch64-static
         ;;
     *)
         fatal "Unknown architecture ${PIECES[2]}."

--- a/helpers/toolset.sh
+++ b/helpers/toolset.sh
@@ -30,6 +30,38 @@ finalise_installation() {
     rm -f .partial
 }
 
+# Gets qemu-user-static 3.1 from Ubuntu 19.04 "Disco Dingo".
+# Globals:
+#     None
+# Arguments:
+#     None
+# Returns:
+#     None
+get_qemu_emulation_binary() {
+    wget http://mirrors.kernel.org/ubuntu/dists/disco/universe/binary-amd64/Packages.xz
+
+    xz -d Packages.xz
+
+    package="$(grep "Filename: pool/universe/q/qemu/qemu-user-static" Packages | awk '{print $2}')"
+
+    wget http://security.ubuntu.com/ubuntu/"${package}"
+
+    ar x "$(basename "${package}")"
+
+    tar xJf data.tar.xz
+
+    cp usr/bin/qemu-aarch64-static .
+    cp usr/bin/qemu-arm-static .
+
+    # cleanup
+    rm    control.tar.xz
+    rm    data.tar.xz
+    rm    debian-binary
+    rm    Packages
+    rm    "$(basename "${package}")"
+    rm -r usr
+}
+
 # Checks if the specified Toolset component is partially installed, and if so,
 # cleans up its directory and initializes it for the installation, creating the
 # .partial file there.

--- a/pieman.sh
+++ b/pieman.sh
@@ -118,7 +118,7 @@ def_bool_var SUDO_REQUIRE_PASSWORD true
 
 def_var TIME_ZONE "Etc/UTC"
 
-def_var TOOLSET_CODENAME "v1-bender"
+def_var TOOLSET_CODENAME "v2-hermes"
 
 def_var TOOLSET_DIR "${PIEMAN_DIR}/toolset"
 

--- a/test/test_functions.sh
+++ b/test/test_functions.sh
@@ -171,13 +171,13 @@ test_choosing_user_mode_emulation_binary() {
 
     choose_user_mode_emulation_binary
 
-    assertEquals "/usr/bin/qemu-arm-static" ${EMULATOR}
+    assertEquals "${TOOLSET_FULL_PATH}"/qemu-user-static/qemu-arm-static ${EMULATOR}
 
     PIECES=(raspbian stretch arm64)
 
     choose_user_mode_emulation_binary
 
-    assertEquals "/usr/bin/qemu-aarch64-static" ${EMULATOR}
+    assertEquals "${TOOLSET_FULL_PATH}"/qemu-user-static/qemu-aarch64-static ${EMULATOR}
 
     PIECES=(raspbian stretch mock)
 

--- a/toolset.sh
+++ b/toolset.sh
@@ -40,6 +40,15 @@ else
     info "Das U-Boot dependencies are satisfied"
 fi
 
+if $(init_installation_if_needed "${TOOLSET_FULL_PATH}/qemu-user-static"); then
+    info "fetching qemu-user-static"
+    pushd "${TOOLSET_FULL_PATH}/qemu-user-static"
+        get_qemu_emulation_binary
+
+        finalise_installation
+    popd
+fi
+
 if $(init_installation_if_needed "${TOOLSET_FULL_PATH}/apk"); then
     info "fetching apk.static for Alpine Linux ${ALPINE_VER}"
     pushd "${TOOLSET_FULL_PATH}"/apk


### PR DESCRIPTION
Closes #160.

These changes help
* solving the problem related to building images on old systems such as Ubuntu 16.04 because of out-of-dated `qemu-arm-static`;
* reduce the number of dependencies which users have to install manually.

Now we can use the latest versions of `qemu-user-static` as a bonus.

---

# Please make sure all below checkboxes in the Mandatory section have been checked before submitting your PR (also don't forget to pay attention to the Depending on Circumstances section)

## Mandatory

- [x] The commit message is an imperative and starts with a capital letter (for example, `Add something`, `Remove something`, `Fix something`, etc.).
- [x] I made sure I hadn't put a period at the end of the the commit message(s).

## Depending on Circumstances

Some of the items in the section become mandatory if you are a first-time contributor and/or your changes are relevant to the items.

- [ ] Adding a new parameter I didn't forget to reflect it in `README.md`.
- [ ] Adding a new parameter or modifying an existing one I didn't break the alphabetical order.
- [ ] Adding a new utility written in Python I didn't forget to reflect it in `pieman/README.md`.
- [ ] Adding a new utility written in Python I didn't forget to increase the version number of the [pieman](https://pypi.org/project/pieman/) package in `pieman/setup.py`, `pieman/pieman/__init__.py` and `essentials.sh`.
- [ ] (for first-time contributors) One of the commits in the pull request adds me to the **Acknowledgements** section in `AUTHORS.md`.
