### PR TITLE
Specify Python 2 explicitly in toolset.sh

### DIFF
--- a/toolset.sh
+++ b/toolset.sh
@@ -131,7 +131,7 @@ if ${mender_dependencies_are_satisfied} && $(init_installation_if_needed "${TOOL
 
         ARCH=arm CROSS_COMPILE="${cross_compiler_for_mender}" make --quiet distclean
         ARCH=arm CROSS_COMPILE="${cross_compiler_for_mender}" make rpi_3_32b_defconfig
-        ARCH=arm CROSS_COMPILE="${cross_compiler_for_mender}" make PYTHON=python -j $(number_of_cores)
+        ARCH=arm CROSS_COMPILE="${cross_compiler_for_mender}" make PYTHON=python2 -j $(number_of_cores)
         ARCH=arm CROSS_COMPILE="${cross_compiler_for_mender}" make envtools -j $(number_of_cores)
 
         cp "u-boot.bin" "${TOOLSET_FULL_PATH}/mender"
@@ -187,12 +187,12 @@ if $(init_installation_if_needed "${TOOLSET_FULL_PATH}/uboot-${UBOOT_VER}"); the
         # The host system may have both Python 2 and 3 installed. U-Boot
         # depends on Python 2, so it's necessary to specify it explicitly via
         # the PYTHON variable.
-        ARCH=arm CROSS_COMPILE="${cross_compiler}" PYTHON=python make -j $(number_of_cores)
+        ARCH=arm CROSS_COMPILE="${cross_compiler}" PYTHON=python2 make -j $(number_of_cores)
 
         cp u-boot-sunxi-with-spl.bin "${TOOLSET_FULL_PATH}/uboot-${UBOOT_VER}"/u-boot-sunxi-with-spl-for-opi-pc-plus.bin
 
         ARCH=arm CROSS_COMPILE="${cross_compiler}" make orangepi_zero_defconfig
-        ARCH=arm CROSS_COMPILE="${cross_compiler}" PYTHON=python make -j $(number_of_cores)
+        ARCH=arm CROSS_COMPILE="${cross_compiler}" PYTHON=python2 make -j $(number_of_cores)
 
         cp u-boot-sunxi-with-spl.bin "${TOOLSET_FULL_PATH}/uboot-${UBOOT_VER}"/u-boot-sunxi-with-spl-for-opi-zero.bin
 


### PR DESCRIPTION
Nowadays python might mean Python 3, so it's necessary to explicitly specify that we need Python 2.

# Please make sure all below checkboxes in the Mandatory section have been checked before submitting your PR (also don't forget to pay attention to the Depending on Circumstances section)

## Mandatory

- [x] The commit message is an imperative and starts with a capital letter (for example, `Add something`, `Remove something`, `Fix something`, etc.).
- [x] I made sure I hadn't put a period at the end of the the commit message(s).

## Depending on Circumstances

Some of the items in the section become mandatory if you are a first-time contributor and/or your changes are relevant to the items.

- [ ] Adding a new parameter I didn't forget to reflect it in `README.md`.
- [ ] Adding a new parameter or modifying an existing one I didn't break the alphabetical order.
- [ ] Adding a new utility written in Python I didn't forget to reflect it in `pieman/README.md`.
- [ ] Adding a new utility written in Python I didn't forget to increase the version number of the [pieman](https://pypi.org/project/pieman/) package in `pieman/setup.py`, `pieman/pieman/__init__.py` and `essentials.sh`.
- [ ] (for first-time contributors) One of the commits in the pull request adds me to the **Acknowledgements** section in `AUTHORS.md`.
