### PR TITLE
Fix get_attr to allow it to output error (if occurs) 

### DIFF
--- a/helpers/image-attribs.sh
+++ b/helpers/image-attribs.sh
@@ -27,10 +27,8 @@
 get_attr() {
     local output=""
 
-    output="$("${PYTHON}" "${PIEMAN_UTILS_DIR}"/image_attrs.py --file="${YML_FILE}" "$@" 2>&1)"
-    # TODO: check exit code directly with e.g. 'if mycmd;'
-    # shellcheck disable=SC2181
-    if [ $? -ne 0 ]; then
+    { output="$("${PYTHON}" "${PIEMAN_UTILS_DIR}"/image_attrs.py --file="${YML_FILE}" "$@" 2>&1)"; exit_code="$?"; } || true
+    if [ "${exit_code}" -ne 0 ]; then
         fatal "while getting the specified attribute from ${YML_FILE} " \
               "occurred the following error: ${output}."
         do_exit

--- a/helpers/image-attribs.sh
+++ b/helpers/image-attribs.sh
@@ -29,7 +29,7 @@ get_attr() {
 
     { output="$("${PYTHON}" "${PIEMAN_UTILS_DIR}"/image_attrs.py --file="${YML_FILE}" "$@" 2>&1)"; exit_code="$?"; } || true
     if [ "${exit_code}" -ne 0 ]; then
-        fatal "while getting the specified attribute from ${YML_FILE} " \
+        fatal "while getting the specified attribute from ${YML_FILE}" \
               "occurred the following error: ${output}."
         do_exit
     fi


### PR DESCRIPTION
Close #223

---
Here's the plan how to test the PR:
* In `devices/rpi-3-b/alpine-3.9-armhf/pieman.yml` replace `repo` for `repos1`.
* Build an image based on Alpine: `sudo env PYTHON=$(pwd)/../pieman-env/bin/python PYTHONPATH=$(pwd)/pieman OS=alpine-3.9-armhf DEVICE=rpi-3-b ./pieman.sh`
* You will see the message `Fatal: while getting the specified attribute from devices/rpi-3-b/alpine-3.9-armhf/pieman.yml  occurred the following error: alpine-3.9-armhf does not have attribute repos.`
---

# Please make sure all below checkboxes in the Mandatory section have been checked before submitting your PR (also don't forget to pay attention to the Depending on Circumstances section)

## Mandatory

- [x] The commit message is an imperative and starts with a capital letter (for example, `Add something`, `Remove something`, `Fix something`, etc.).
- [x] I made sure I hadn't put a period at the end of the the commit message(s).

## Depending on Circumstances

Some of the items in the section become mandatory if you are a first-time contributor and/or your changes are relevant to the items.

- [ ] Adding a new parameter I didn't forget to reflect it in `README.md`.
- [ ] Adding a new parameter or modifying an existing one I didn't break the alphabetical order.
- [ ] Adding a new utility written in Python I didn't forget to reflect it in `pieman/README.md`.
- [ ] Adding a new utility written in Python I didn't forget to increase the version number of the [pieman](https://pypi.org/project/pieman/) package in `pieman/setup.py`, `pieman/pieman/__init__.py` and `essentials.sh`.
- [ ] (for first-time contributors) One of the commits in the pull request adds me to the **Acknowledgements** section in `AUTHORS.md`.
