### PR TITLE
Make toolset fetch qemu-user-static from Ubuntu 20.04

### DIFF
--- a/helpers/toolset.sh
+++ b/helpers/toolset.sh
@@ -40,7 +40,7 @@ finalise_installation() {
 get_qemu_emulation_binary() {
     local package
     
-    do_wget http://mirrors.kernel.org/ubuntu/dists/disco/universe/binary-amd64/Packages.xz
+    do_wget http://mirrors.kernel.org/ubuntu/dists/focal/universe/binary-amd64/Packages.xz
 
     xz -d Packages.xz
 


### PR DESCRIPTION
We must update it since it's not possible to fetch `qemu-user-static` from Ubuntu 19.04 anymore.

```
wget http://mirrors.kernel.org/ubuntu/dists/disco/universe/binary-amd64/Packages.xz
```

ends up with 404.

---

# Please make sure all below checkboxes in the Mandatory section have been checked before submitting your PR (also don't forget to pay attention to the Depending on Circumstances section)

## Mandatory

- [x] The commit message is an imperative and starts with a capital letter (for example, `Add something`, `Remove something`, `Fix something`, etc.).
- [x] I made sure I hadn't put a period at the end of the the commit message(s).

## Depending on Circumstances

Some of the items in the section become mandatory if you are a first-time contributor and/or your changes are relevant to the items.

- [ ] Adding a new parameter I didn't forget to reflect it in `README.md`.
- [ ] Adding a new parameter or modifying an existing one I didn't break the alphabetical order.
- [ ] Adding a new utility written in Python I didn't forget to reflect it in `pieman/README.md`.
- [ ] Adding a new utility written in Python I didn't forget to increase the version number of the [pieman](https://pypi.org/project/pieman/) package in `pieman/setup.py`, `pieman/pieman/__init__.py` and `essentials.sh`.
- [ ] (for first-time contributors) One of the commits in the pull request adds me to the **Acknowledgements** section in `AUTHORS.md`.
