### PR TITLE
Remove check_required_directories function

### DIFF
--- a/helpers/fs.sh
+++ b/helpers/fs.sh
@@ -33,24 +33,6 @@ calc_size() {
     "${PYTHON}" "${PIEMAN_UTILS_DIR}"/du.py --block-size="${block_size}" ${opts} "${dir}" | grep "Total size" | cut -d':' -f2 | xargs
 }
 
-# Checks if the required directories exist.
-# Globals:
-#     None
-# Arguments:
-#     None
-# Returns:
-#     None
-check_required_directories() {
-    dirs="bootstrap devices"
-
-    for dir in ${dirs}; do
-        if [ ! -d "${dir}" ] ; then
-            fatal "${dir} required directory not found!"
-            do_exit
-        fi
-    done
-}
-
 # Checks if the required files exist.
 # Globals:
 #     YML_FILE

--- a/pieman.sh
+++ b/pieman.sh
@@ -199,8 +199,6 @@ check_ownership_format
 
 check_redis # relevant only if ENABLE_BSC_CHANNEL is set to true
 
-check_required_directories
-
 check_required_files
 
 split_os_name_into_pieces


### PR DESCRIPTION
The idea of checking if the required directories exist doesn't seem good enough. It used to check 'bootstrap' and 'devices' which are the part of the source tree. Moreover, there is no interface to make Pieman use different ones.

---

# Please make sure all below checkboxes in the Mandatory section have been checked before submitting your PR (also don't forget to pay attention to the Depending on Circumstances section)

## Mandatory

- [x] The commit message is an imperative and starts with a capital letter (for example, `Add something`, `Remove something`, `Fix something`, etc.).
- [x] I made sure I hadn't put a period at the end of the the commit message(s).

## Depending on Circumstances

Some of the items in the section become mandatory if you are a first-time contributor and/or your changes are relevant to the items.

- [ ] Adding a new parameter I didn't forget to reflect it in `README.md`.
- [ ] Adding a new parameter or modifying an existing one I didn't break the alphabetical order.
- [ ] Adding a new utility written in Python I didn't forget to reflect it in `pieman/README.md`.
- [ ] Adding a new utility written in Python I didn't forget to increase the version number of the [pieman](https://pypi.org/project/pieman/) package in `pieman/setup.py`, `pieman/pieman/__init__.py` and `essentials.sh`.
- [ ] (for first-time contributors) One of the commits in the pull request adds me to the **Acknowledgements** section in `AUTHORS.md`.
