### PR TITLE
Override sdist setuptools command in pieman-devices setup.py

### DIFF
--- a/devices/setup.py
+++ b/devices/setup.py
@@ -153,7 +153,7 @@ def main():
     """The main entry point. """
 
     setup(name=PACKAGE_NAME,
-          version='0.1',
+          version='0.2',
           description='Pieman devices package',
           long_description=LONG_DESCRIPTION,
           url='https://github.com/tolstoyevsky/pieman/tree/master/devices',

--- a/devices/setup.py
+++ b/devices/setup.py
@@ -143,7 +143,7 @@ def main():
           version='0.1',
           description='Pieman devices package',
           long_description=LONG_DESCRIPTION,
-          url='https://github.com/tolstoyevsky/pieman',
+          url='https://github.com/tolstoyevsky/pieman/tree/master/devices',
           author='Evgeny Golyshev',
           maintainer='Evgeny Golyshev',
           maintainer_email='eugulixes@gmail.com',


### PR DESCRIPTION
# Please make sure all below checkboxes in the Mandatory section have been checked before submitting your PR (also don't forget to pay attention to the Depending on Circumstances section)

## Mandatory

- [x] The commit message is an imperative and starts with a capital letter (for example, `Add something`, `Remove something`, `Fix something`, etc.).
- [x] I made sure I hadn't put a period at the end of the the commit message(s).

## Depending on Circumstances

Some of the items in the section become mandatory if you are a first-time contributor and/or your changes are relevant to the items.

- [ ] Adding a new parameter I didn't forget to reflect it in `README.md`.
- [ ] Adding a new parameter or modifying an existing one I didn't break the alphabetical order.
- [ ] Adding a new utility written in Python I didn't forget to reflect it in `pieman/README.md`.
- [ ] Adding a new utility written in Python I didn't forget to increase the version number of the [pieman](https://pypi.org/project/pieman/) package in `pieman/setup.py`, `pieman/pieman/__init__.py` and `essentials.sh`.
- [ ] (for first-time contributors) One of the commits in the pull request adds me to the **Acknowledgements** section in `AUTHORS.md`.
