### PR TITLE
Delete check_if_variable_is_set from bootstrap scripts

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,3 +14,4 @@ We thank all the contributors to the project. Here is the full list of the peopl
 * [Anton Maksimovich](https://github.com/ABSLord)
 * [Dmitriy Ivanko](https://github.com/Themanwhosmellslikesugar)
 * [Vladislav Iarovoy](https://github.com/IrovoyVlad)
+* [Artem Lavruhin](https://github.com/Artem4590)

--- a/bootstrap/10-rootfs-partition.sh
+++ b/bootstrap/10-rootfs-partition.sh
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-check_if_variable_is_set R
-
 # Expand the base system.
 
 if is_debian_based; then

--- a/bootstrap/11-locale.sh
+++ b/bootstrap/11-locale.sh
@@ -14,11 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-if ! check_if_variable_is_set TIME_ZONE; then
-    >&2 echo "TIME_ZONE is not specified"
-    exit 1
-fi
-
 info "setting up locale"
 
 if is_debian_based; then

--- a/bootstrap/12-pm.sh
+++ b/bootstrap/12-pm.sh
@@ -13,10 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-for var in CREATE_ONLY_CHROOT ENABLE_NONFREE ENABLE_UNIVERSE ETC PIECES; do
-    check_if_variable_is_set ${var}
-done
-
 if ${ALLOW_UNAUTHENTICATED}; then
     if is_alpine; then
         add_option_to_pm_options --allow-untrusted

--- a/bootstrap/13-kernel.sh
+++ b/bootstrap/13-kernel.sh
@@ -13,9 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-for var in OS SOURCE_DIR; do
-    check_if_variable_is_set ${var}
-done
 
 kernel_package="$(get_attr kernel package)"
 

--- a/bootstrap/14-boot-partition.sh
+++ b/bootstrap/14-boot-partition.sh
@@ -18,8 +18,6 @@
 # requires some of the files which are available only after installation all
 # of the specified packages, including the kernel package.
 
-check_if_variable_is_set SOURCE_DIR
-
 # Get the files, which must present on the boot partition, from different
 # sources and put them in the directory specified via BOOT.
 boot="$(get_attr boot)"

--- a/bootstrap/15-networking.sh
+++ b/bootstrap/15-networking.sh
@@ -13,13 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-check_if_variable_is_set \
-    ENABLE_CUSTOM_DNS \
-    ENABLE_BASIC_YANDEX_DNS \
-    ENABLE_FAMILY_YANDEX_DNS \
-    ENABLE_GOOGLE_DNS \
-    ETC
-
 dns_addr1=""
 dns_addr2=""
 dns_is_set=false

--- a/bootstrap/20-users.sh
+++ b/bootstrap/20-users.sh
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-check_if_variable_is_set ENABLE_USER PASSWORD USER_NAME USER_PASSWORD
-
 if ${ENABLE_USER}; then
     info "creating regular user ${USER_NAME}"
     add_user "${USER_NAME}" "${USER_PASSWORD}"

--- a/bootstrap/50-firstboot.sh
+++ b/bootstrap/50-firstboot.sh
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-check_if_variable_is_set ETC
-
 if is_alpine; then
     info "Adding the local service to the default runlevel"
     chroot_exec rc-update add local default


### PR DESCRIPTION
I want close #305 issue

---

# Please make sure all below checkboxes in the Mandatory section have been checked before submitting your PR (also don't forget to pay attention to the Depending on Circumstances section)

## Mandatory

- [x] The commit message is an imperative and starts with a capital letter (for example, `Add something`, `Remove something`, `Fix something`, etc.).
- [x] I made sure I hadn't put a period at the end of the the commit message(s).

## Depending on Circumstances

Some of the items in the section become mandatory if you are a first-time contributor and/or your changes are relevant to the items.

- [ ] Adding a new parameter I didn't forget to reflect it in `README.md`.
- [ ] Adding a new parameter or modifying an existing one I didn't break the alphabetical order.
- [ ] Adding a new utility written in Python I didn't forget to reflect it in `pieman/README.md`.
- [ ] Adding a new utility written in Python I didn't forget to increase the version number of the [pieman](https://pypi.org/project/pieman/) package in `pieman/setup.py`, `pieman/pieman/__init__.py` and `essentials.sh`.
- [x] (for first-time contributors) One of the commits in the pull request adds me to the **Acknowledgements** section in `AUTHORS.md`.
